### PR TITLE
Add Korean and English language toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,24 +8,64 @@
   const statusLine = document.getElementById('status');
   const historyList = document.getElementById('history');
   const errorBox = document.getElementById('error');
+  const titleEl = document.querySelector('h1');
+  const minLabel = document.querySelector('label[for="min"]');
+  const maxLabel = document.querySelector('label[for="max"]');
+  const repeatText = document.querySelector('.switch-text');
+  const historyHeading = document.querySelector('.history h2');
+  const langKoBtn = document.getElementById('lang-ko');
+  const langEnBtn = document.getElementById('lang-en');
+
+  const translations = {
+    en: {
+      title: 'Singaseong Numbers',
+      min: 'Minimum',
+      max: 'Maximum',
+      allowRepeats: 'Allow repeats',
+      generate: 'Generate',
+      reset: 'Reset',
+      range: 'Range',
+      generated: 'Generated',
+      history: 'History',
+      enterRange: 'Please enter both minimum and maximum numbers.',
+      allGenerated: 'All numbers in the range have been generated.'
+    },
+    ko: {
+      title: '신가성의 숫자들',
+      min: '최소',
+      max: '최대',
+      allowRepeats: '반복 허용',
+      generate: '생성',
+      reset: '초기화',
+      range: '범위',
+      generated: '만든 숫자',
+      history: '히스토리',
+      enterRange: '최소와 최대 값을 입력하세요.',
+      allGenerated: '범위의 모든 숫자를 생성했습니다.'
+    }
+  };
+
+  let currentLang = 'ko';
+  let currentErrorKey = null;
 
   let allowRepeats = true;
   let generatedSet = new Set();
   let count = 0;
 
-  function setError(msg) {
-    errorBox.textContent = msg;
+  function setError(key) {
+    currentErrorKey = key;
+    errorBox.textContent = key ? translations[currentLang][key] : '';
   }
 
   function clearError() {
-    errorBox.textContent = '';
+    setError(null);
   }
 
   function getRange() {
     const min = parseInt(minInput.value, 10);
     const max = parseInt(maxInput.value, 10);
     if (Number.isNaN(min) || Number.isNaN(max)) {
-      setError('Please enter both minimum and maximum numbers.');
+      setError('enterRange');
       return null;
     }
     if (min > max) {
@@ -37,7 +77,8 @@
   }
 
   function updateStatus(min, max, countVal) {
-    statusLine.textContent = `Range: ${min}–${max} • Generated: ${countVal}`;
+    const t = translations[currentLang];
+    statusLine.textContent = `${t.range}: ${min}–${max} • ${t.generated}: ${countVal}`;
   }
 
   function renderResult(value) {
@@ -73,7 +114,7 @@
     const total = max - min + 1;
     if (!allowRepeats) {
       if (generatedSet.size === total) {
-        setError('All numbers in the range have been generated.');
+        setError('allGenerated');
         generateBtn.disabled = true;
         return;
       }
@@ -104,6 +145,27 @@
     allowRepeats = repeatToggle.checked;
   });
 
-  updateStatus('—', '—', 0);
+  function switchLanguage(lang) {
+    currentLang = lang;
+    const t = translations[lang];
+    document.documentElement.lang = lang;
+    document.title = t.title;
+    titleEl.textContent = t.title;
+    minLabel.textContent = t.min;
+    maxLabel.textContent = t.max;
+    repeatText.textContent = t.allowRepeats;
+    generateBtn.textContent = t.generate;
+    resetBtn.textContent = t.reset;
+    historyHeading.textContent = t.history;
+    const minVal = minInput.value || '—';
+    const maxVal = maxInput.value || '—';
+    updateStatus(minVal, maxVal, count);
+    if (currentErrorKey) setError(currentErrorKey);
+  }
+
+  langKoBtn.addEventListener('click', () => switchLanguage('ko'));
+  langEnBtn.addEventListener('click', () => switchLanguage('en'));
+
+  switchLanguage('ko');
   renderResult('—');
 })();

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Singaseong Numbers</title>
+  <title>신가성의 숫자들</title>
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
@@ -16,34 +16,38 @@
   <a href="https://singaseongj.github.io/" class="home-button" aria-label="Home">&#x21A9;</a>
   <main class="container">
     <header>
-      <h1>Singaseong Numbers</h1>
+      <h1>신가성의 숫자들</h1>
     </header>
     <section id="result" class="display" aria-live="polite">—</section>
     <section class="controls">
       <div class="field">
-        <label for="min">Minimum</label>
+        <label for="min">최소</label>
         <input type="number" id="min">
       </div>
       <div class="field">
-        <label for="max">Maximum</label>
+        <label for="max">최대</label>
         <input type="number" id="max">
       </div>
       <div class="field switch-field">
         <input type="checkbox" id="repeatToggle" checked>
         <label for="repeatToggle" class="switch-slider"></label>
-        <label for="repeatToggle" class="switch-text">Allow repeats</label>
+        <label for="repeatToggle" class="switch-text">반복 허용</label>
       </div>
       <div class="buttons">
-        <button id="generate">Generate</button>
-        <button id="reset" type="reset">Reset</button>
+        <button id="generate">생성</button>
+        <button id="reset" type="reset">초기화</button>
       </div>
     </section>
     <p id="error" class="error" aria-live="polite"></p>
-    <p id="status" class="status" aria-live="polite">Range: —–— • Generated: 0</p>
+    <p id="status" class="status" aria-live="polite">범위: —–— • 만든 숫자: 0</p>
     <section class="history">
-      <h2>History</h2>
+      <h2>히스토리</h2>
       <ul id="history"></ul>
     </section>
+    <div class="lang-buttons">
+      <button id="lang-ko" type="button">한국어</button>
+      <button id="lang-en" type="button">English</button>
+    </div>
   </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -153,6 +153,15 @@ button:focus, input:focus {
   border-radius: 4px;
 }
 
+.lang-buttons {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.lang-buttons button {
+  margin: 0 0.5rem;
+}
+
 .home-button {
   position: fixed;
   top: 10px;


### PR DESCRIPTION
## Summary
- Default site to Korean and translate core UI text
- Add language toggle buttons for Korean and English
- Implement language switching logic in app.js and style buttons

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_68b652bb21dc832aaa40e11f69fcb507