### PR TITLE
feat: export history via clipboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,8 @@
   const maxLabel = document.querySelector('label[for="max"]');
   const repeatText = document.querySelector('.switch-text');
   const historyHeading = document.querySelector('.history h2');
+  const copyBtn = document.getElementById('copyHistory');
+  const copyMessage = document.getElementById('copyMessage');
   const langKoBtn = document.getElementById('lang-ko');
   const langEnBtn = document.getElementById('lang-en');
 
@@ -27,6 +29,8 @@
       range: 'Range',
       generated: 'Generated',
       history: 'History',
+      copy: 'Copy',
+      copied: 'Copied to clipboard',
       enterRange: 'Please enter both minimum and maximum numbers.',
       allGenerated: 'All numbers in the range have been generated.'
     },
@@ -40,6 +44,8 @@
       range: '범위',
       generated: '만든 숫자',
       history: '히스토리',
+      copy: '복사',
+      copied: '클립보드에 복사완료',
       enterRange: '최소와 최대 값을 입력하세요.',
       allGenerated: '범위의 모든 숫자를 생성했습니다.'
     }
@@ -145,6 +151,14 @@
     allowRepeats = repeatToggle.checked;
   });
 
+  copyBtn.addEventListener('click', () => {
+    const items = Array.from(historyList.children).map(li => li.textContent);
+    if (!items.length) return;
+    navigator.clipboard.writeText(items.join('\n')).then(() => {
+      copyMessage.textContent = translations[currentLang].copied;
+    });
+  });
+
   function switchLanguage(lang) {
     currentLang = lang;
     const t = translations[lang];
@@ -157,6 +171,8 @@
     generateBtn.textContent = t.generate;
     resetBtn.textContent = t.reset;
     historyHeading.textContent = t.history;
+    copyBtn.textContent = t.copy;
+    if (copyMessage.textContent) copyMessage.textContent = t.copied;
     const minVal = minInput.value || '—';
     const maxVal = maxInput.value || '—';
     updateStatus(minVal, maxVal, count);

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
     <section class="history">
       <h2>히스토리</h2>
       <ul id="history"></ul>
+      <button id="copyHistory" type="button">복사</button>
+      <p id="copyMessage" class="status" aria-live="polite"></p>
     </section>
     <div class="lang-buttons">
       <button id="lang-ko" type="button">한국어</button>

--- a/styles.css
+++ b/styles.css
@@ -169,6 +169,10 @@ button:focus, input:focus {
   border-radius: 4px;
 }
 
+.history button {
+  margin-top: 0.5rem;
+}
+
 .lang-buttons {
   margin-top: 1.5rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- add copy button to export generated number history
- support English and Korean copy messages
- style history button spacing

## Testing
- `node --check app.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6d5658f98832a93d86b3f8fa187be