### PR TITLE
Use icon-only copy button with transient tooltip

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@
   const repeatText = document.querySelector('.switch-text');
   const historyHeading = document.querySelector('.history h2');
   const copyBtn = document.getElementById('copyHistory');
-  const copyMessage = document.getElementById('copyMessage');
+  const copyTooltip = document.getElementById('copyTooltip');
   const langKoBtn = document.getElementById('lang-ko');
   const langEnBtn = document.getElementById('lang-en');
 
@@ -154,8 +154,12 @@
   copyBtn.addEventListener('click', () => {
     const items = Array.from(historyList.children).map(li => li.textContent);
     if (!items.length) return;
-    navigator.clipboard.writeText(items.join('\n')).then(() => {
-      copyMessage.textContent = translations[currentLang].copied;
+    navigator.clipboard.writeText(items.join(' ')).then(() => {
+      copyTooltip.textContent = translations[currentLang].copied;
+      copyTooltip.classList.add('show');
+      setTimeout(() => {
+        copyTooltip.classList.remove('show');
+      }, 1500);
     });
   });
 
@@ -171,8 +175,8 @@
     generateBtn.textContent = t.generate;
     resetBtn.textContent = t.reset;
     historyHeading.textContent = t.history;
-    copyBtn.textContent = t.copy;
-    if (copyMessage.textContent) copyMessage.textContent = t.copied;
+    copyBtn.setAttribute('aria-label', t.copy);
+    if (copyTooltip.textContent) copyTooltip.textContent = t.copied;
     const minVal = minInput.value || '—';
     const maxVal = maxInput.value || '—';
     updateStatus(minVal, maxVal, count);

--- a/index.html
+++ b/index.html
@@ -43,8 +43,12 @@
     <section class="history">
       <h2>히스토리</h2>
       <ul id="history"></ul>
-      <button id="copyHistory" type="button">복사</button>
-      <p id="copyMessage" class="status" aria-live="polite"></p>
+      <div class="copy-wrapper">
+        <button id="copyHistory" type="button" aria-label="복사">
+          <img src="src/copy.svg" alt="">
+        </button>
+        <span id="copyTooltip" class="tooltip" aria-live="polite"></span>
+      </div>
     </section>
     <div class="lang-buttons">
       <button id="lang-ko" type="button">한국어</button>

--- a/src/copy.svg
+++ b/src/copy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -173,6 +173,35 @@ button:focus, input:focus {
   margin-top: 0.5rem;
 }
 
+.copy-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.copy-wrapper img {
+  width: 16px;
+  height: 16px;
+}
+
+.tooltip {
+  position: absolute;
+  top: -1.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.tooltip.show {
+  opacity: 1;
+}
+
 .lang-buttons {
   margin-top: 1.5rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- Replace text-based history copy button with a simple icon and new tooltip container
- Show a temporary "Copied to clipboard" tooltip and copy numbers with spaces
- Add copy.svg asset and styling for tooltip positioning

## Testing
- ⚠️ `xdg-open index.html` *(command not found: xdg-open)*

------
https://chatgpt.com/codex/tasks/task_b_68b6d94cfbe4832aa71f3dad67000a6e