### PR TITLE
feat: add erase button and refresh styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@
   const copyTooltip = document.getElementById('copyTooltip');
   const langKoBtn = document.getElementById('lang-ko');
   const langEnBtn = document.getElementById('lang-en');
+  const eraseBtn = document.getElementById('erase');
 
   const translations = {
     en: {
@@ -54,7 +55,7 @@
   let currentLang = 'ko';
   let currentErrorKey = null;
 
-  let allowRepeats = true;
+  let allowRepeats = false;
   let generatedSet = new Set();
   let count = 0;
 
@@ -100,8 +101,8 @@
   function resetState() {
     minInput.value = '';
     maxInput.value = '';
-    allowRepeats = true;
-    repeatToggle.checked = true;
+    allowRepeats = false;
+    repeatToggle.checked = false;
     generatedSet.clear();
     count = 0;
     historyList.innerHTML = '';
@@ -151,6 +152,18 @@
     allowRepeats = repeatToggle.checked;
   });
 
+  eraseBtn.addEventListener('click', () => {
+    generatedSet.clear();
+    count = 0;
+    historyList.innerHTML = '';
+    renderResult('—');
+    clearError();
+    generateBtn.disabled = false;
+    const minVal = minInput.value || '—';
+    const maxVal = maxInput.value || '—';
+    updateStatus(minVal, maxVal, 0);
+  });
+
   copyBtn.addEventListener('click', () => {
     const items = Array.from(historyList.children).map(li => li.textContent);
     if (!items.length) return;
@@ -186,6 +199,7 @@
   langKoBtn.addEventListener('click', () => switchLanguage('ko'));
   langEnBtn.addEventListener('click', () => switchLanguage('en'));
 
+  repeatToggle.checked = false;
   switchLanguage('ko');
   renderResult('—');
 })();

--- a/index.html
+++ b/index.html
@@ -29,12 +29,13 @@
         <input type="number" id="max">
       </div>
       <div class="field switch-field">
-        <input type="checkbox" id="repeatToggle" checked>
+        <input type="checkbox" id="repeatToggle">
         <label for="repeatToggle" class="switch-slider"></label>
         <label for="repeatToggle" class="switch-text">반복 허용</label>
       </div>
       <div class="buttons">
         <button id="generate">생성</button>
+        <button id="erase" type="button">Erase</button>
         <button id="reset" type="reset">초기화</button>
       </div>
     </section>
@@ -52,6 +53,7 @@
     </section>
     <div class="lang-buttons">
       <button id="lang-ko" type="button">한국어</button>
+      <span class="lang-sep" aria-hidden="true">|</span>
       <button id="lang-en" type="button">English</button>
     </div>
   </main>

--- a/styles.css
+++ b/styles.css
@@ -84,7 +84,7 @@ h1 {
 }
 
 .switch-field input[type=checkbox]:checked {
-  background: #007acc;
+  background: #2563eb;
 }
 
 .switch-field input[type=checkbox]:checked::before {
@@ -101,30 +101,44 @@ button {
   padding: 0.6rem 1.2rem;
   border: none;
   border-radius: 4px;
-  background: #007acc;
+  background: #2563eb;
   color: #fff;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s, box-shadow 0.2s;
 }
 
 button:hover {
-  background: #005fa3;
+  background: #1d4ed8;
+}
+
+button:active {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  transform: translateY(1px);
 }
 
 #generate {
-  background: #28a745;
+  background: #22c55e;
 }
 
 #generate:hover {
-  background: #1e7e34;
+  background: #16a34a;
 }
 
 #reset {
-  background: #dc3545;
+  background: #ef4444;
 }
 
 #reset:hover {
-  background: #b02a37;
+  background: #dc2626;
+}
+
+#erase {
+  background: #facc15;
+  color: #000;
+}
+
+#erase:hover {
+  background: #eab308;
 }
 
 button:disabled {
@@ -133,7 +147,7 @@ button:disabled {
 }
 
 button:focus, input:focus {
-  outline: 2px solid #005fa3;
+  outline: 2px solid #1d4ed8;
   outline-offset: 2px;
 }
 
@@ -173,9 +187,20 @@ button:focus, input:focus {
   margin-top: 0.5rem;
 }
 
+
 .copy-wrapper {
   position: relative;
   display: inline-block;
+}
+
+#copyHistory {
+  background: transparent;
+  padding: 0;
+  color: #000;
+}
+
+#copyHistory:hover {
+  background: transparent;
 }
 
 .copy-wrapper img {
@@ -196,6 +221,7 @@ button:focus, input:focus {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s;
+  white-space: nowrap;
 }
 
 .tooltip.show {
@@ -209,6 +235,10 @@ button:focus, input:focus {
 
 .lang-buttons button {
   margin: 0 0.5rem;
+}
+
+.lang-sep {
+  color: #888;
 }
 
 .home-button {


### PR DESCRIPTION
## Summary
- add yellow "Erase" button to clear history without altering range
- restyle buttons with modern colors and shadows; copy icon now transparent
- default repeats toggle to off and widen copy tooltip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6ddb98dbc832a83eb25f77a742e3d