### PR TITLE
Translate erase button to Korean and style text

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@
       allowRepeats: 'Allow repeats',
       generate: 'Generate',
       reset: 'Reset',
+      erase: 'Erase',
       range: 'Range',
       generated: 'Generated',
       history: 'History',
@@ -42,6 +43,7 @@
       allowRepeats: '반복 허용',
       generate: '생성',
       reset: '초기화',
+      erase: '지우기',
       range: '범위',
       generated: '만든 숫자',
       history: '히스토리',
@@ -187,6 +189,7 @@
     repeatText.textContent = t.allowRepeats;
     generateBtn.textContent = t.generate;
     resetBtn.textContent = t.reset;
+    eraseBtn.textContent = t.erase;
     historyHeading.textContent = t.history;
     copyBtn.setAttribute('aria-label', t.copy);
     if (copyTooltip.textContent) copyTooltip.textContent = t.copied;

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       </div>
       <div class="buttons">
         <button id="generate">생성</button>
-        <button id="erase" type="button">Erase</button>
+        <button id="erase" type="button">지우기</button>
         <button id="reset" type="reset">초기화</button>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -134,7 +134,7 @@ button:active {
 
 #erase {
   background: #facc15;
-  color: #000;
+  color: #fff;
 }
 
 #erase:hover {


### PR DESCRIPTION
## Summary
- Localize Erase button as 지우기 and ensure text is white
- Add translation entries and update language switcher for Erase button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6e13af9b8832a8ed7966dabe5aeef