### PR TITLE
Preassign random groups for numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         <span id="copyTooltip" class="tooltip" aria-live="polite"></span>
       </div>
     </section>
-    <section class="groups">
+    <section id="groupsSection" class="groups" style="display:none;">
       <h2 id="groupsHeading">그룹</h2>
       <div id="groupsContainer" class="groups-container"></div>
     </section>


### PR DESCRIPTION
## Summary
- Randomly assign each number to a fixed group before generation
- Reveal the group of each generated number and show group listings only after numbers appear
- Reset and erase now clear group assignments and hide the group section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b931c67288832aa156d0523e04f0aa