### PR TITLE
Display group number smaller next to drawn result

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,8 +119,7 @@
 
   function renderResult(value, group) {
     if (group) {
-      const t = translations[currentLang];
-      resultDisplay.textContent = `${value} (${t.group} ${group})`;
+      resultDisplay.innerHTML = `${value} <span class="group-number">(${group})</span>`;
     } else {
       resultDisplay.textContent = value;
     }

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,10 @@ h1 {
   margin: 1rem 0;
 }
 
+#result .group-number {
+  font-size: 0.5em;
+}
+
 .controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Show drawn number with its group number in parentheses using reduced font size.
- Add CSS rule to scale group number to half the size of the main number.

## Testing
- `npm test`
- `python3 -m http.server 8000` (verified 200 response via curl)

------
https://chatgpt.com/codex/tasks/task_b_68b9350b4734832aa3f9d2c541b00de0