### PR TITLE
Clarify group heading text

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,7 @@
       copied: 'Copied to clipboard',
       enterRange: 'Please enter both minimum and maximum numbers.',
       allGenerated: 'All numbers in the range have been generated.',
-      groups: 'Groups',
+      groups: 'Groups of 4 or 5',
       group: 'Group'
     },
     ko: {
@@ -56,7 +56,7 @@
       copied: '클립보드에 복사완료',
       enterRange: '최소와 최대 값을 입력하세요.',
       allGenerated: '범위의 모든 숫자를 생성했습니다.',
-      groups: '그룹',
+      groups: '그룹(4인 또는 5인 1조)',
       group: '그룹'
     }
   };

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       </div>
     </section>
     <section id="groupsSection" class="groups" style="display:none;">
-      <h2 id="groupsHeading">그룹</h2>
+      <h2 id="groupsHeading">그룹(4인 또는 5인 1조)</h2>
       <div id="groupsContainer" class="groups-container"></div>
     </section>
     <div class="lang-buttons">


### PR DESCRIPTION
## Summary
- Clarify group section heading to "Groups of 4 or 5" in English and its Korean equivalent
- Update translations so group heading renders correctly in both languages

## Testing
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b940f2ae60832a8bb7b8c797c3b07f