### PR TITLE
feat: apply 4-person priority grouping

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,9 +118,7 @@
       const remainder = total % groupCount;
       for (let i = 0; i < remainder; i++) groupSizes[i]++;
     } else {
-      groupCount = Math.round(total / 4.5);
-      if (groupCount < gMin) groupCount = gMin;
-      if (groupCount > gMax) groupCount = gMax;
+      groupCount = gMax;
       const fiveGroups = total - 4 * groupCount;
       groupSizes = Array(groupCount).fill(4);
       for (let i = 0; i < fiveGroups; i++) groupSizes[i]++;


### PR DESCRIPTION
## Summary
- prioritize 4-person groups when forming groups of 4 or 5
- fall back to even-sized groups when 4 or 5-only grouping is impossible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ba2a90c520832ab601a1368f6fb675