### PR TITLE
Add customizable group size inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,9 @@
     </section>
     <section id="groupsSection" class="groups" style="display:none;">
       <div class="groups-header">
-        <h2 id="groupsHeading">그룹(4인 또는 5인 1조)</h2>
+        <h2 id="groupsHeading">그룹 내 인원</h2>
+        <input type="number" id="gsizeMin" class="gsize-input" min="1">
+        <input type="number" id="gsizeMax" class="gsize-input" min="1">
         <button id="generateAll" type="button">모두 생성</button>
       </div>
       <div id="groupsContainer" class="groups-container"></div>

--- a/styles.css
+++ b/styles.css
@@ -205,6 +205,13 @@ button:focus, input:focus {
   gap: 0.5rem;
 }
 
+.groups-header .gsize-input {
+  width: 3rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
 .groups-container {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- allow custom group size ranges using new input fields
- unify draw order between single and bulk generation
- restyle group header for additional controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ba30bc1fd4832a8fd9a20e3198eeef