### PR TITLE
Prefer fewer groups and expose group controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,6 @@
   const errorBox = document.getElementById('error');
   const groupsContainer = document.getElementById('groupsContainer');
   const groupsHeading = document.getElementById('groupsHeading');
-  const groupsSection = document.getElementById('groupsSection');
   const generateAllBtn = document.getElementById('generateAll');
   const titleEl = document.querySelector('h1');
   const minLabel = document.querySelector('label[for="min"]');
@@ -129,7 +128,7 @@
     drawQueue = nums.slice();
     drawIndex = 0;
 
-    // Generalized sizing: each group within [sMin, sMax], prefer smaller (sMin).
+    // Generalized sizing: each group within [sMin, sMax], prefer fewer groups (larger size).
     const { sMin, sMax } = getGroupSizeRange();
     const gCountMin = Math.ceil(total / sMax);
     const gCountMax = Math.floor(total / sMin);
@@ -138,8 +137,8 @@
     let groupSizes = [];
 
     if (gCountMin <= gCountMax) {
-      // Try the most groups first (more, smaller groups)
-      for (let g = gCountMax; g >= gCountMin; g--) {
+      // Try the fewest groups first (fewer, larger groups)
+      for (let g = gCountMin; g <= gCountMax; g++) {
         const extra = total - sMin * g; // how many +1s we must distribute
         const capacity = g * (sMax - sMin);
         if (extra >= 0 && extra <= capacity) {
@@ -213,12 +212,13 @@
       wrapper.appendChild(ul);
       groupsContainer.appendChild(wrapper);
     });
-    groupsSection.style.display = groupsContainer.childElementCount ? 'block' : 'none';
   }
 
   function resetState() {
     minInput.value = '';
     maxInput.value = '';
+    gsizeMinInput.value = 4;
+    gsizeMaxInput.value = 5;
     allowRepeats = false;
     repeatToggle.checked = false;
     generatedSet.clear();
@@ -230,7 +230,6 @@
     groupLists = [];
     drawQueue = [];
     drawIndex = 0;
-    groupsSection.style.display = 'none';
     renderResult('—');
     clearError();
     generateBtn.disabled = false;
@@ -271,6 +270,8 @@
 
   function generateAllNumbers() {
     clearError();
+    allowRepeats = false;
+    repeatToggle.checked = false;
     const range = getRange();
     if (!range) return;
     const { min, max } = range;
@@ -330,7 +331,8 @@
     groupLists = [];
     drawQueue = [];
     drawIndex = 0;
-    groupsSection.style.display = 'none';
+    allowRepeats = false;
+    repeatToggle.checked = false;
     renderResult('—');
     clearError();
     generateBtn.disabled = false;
@@ -384,6 +386,8 @@
   langKoBtn.addEventListener('click', () => switchLanguage('ko'));
   langEnBtn.addEventListener('click', () => switchLanguage('en'));
 
+  gsizeMinInput.value = 4;
+  gsizeMaxInput.value = 5;
   repeatToggle.checked = false;
   switchLanguage('ko');
 })();

--- a/index.html
+++ b/index.html
@@ -51,11 +51,11 @@
         <span id="copyTooltip" class="tooltip" aria-live="polite"></span>
       </div>
     </section>
-    <section id="groupsSection" class="groups" style="display:none;">
+    <section id="groupsSection" class="groups">
       <div class="groups-header">
         <h2 id="groupsHeading">그룹 내 인원</h2>
-        <input type="number" id="gsizeMin" class="gsize-input" min="1">
-        <input type="number" id="gsizeMax" class="gsize-input" min="1">
+        <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
+        <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
         <button id="generateAll" type="button">모두 생성</button>
       </div>
       <div id="groupsContainer" class="groups-container"></div>


### PR DESCRIPTION
## Summary
- Prefer smallest number of groups when sizing and distributing members
- Show group controls at all times and initialize group size inputs to 4–5
- Ensure Generate All produces unique numbers and disables repeats

## Testing
- `node --check app.js`
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba3511cbf0832aa70d5c638ea97bea