### PR TITLE
feat: add countdown before generating all

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@
   const eraseBtn = document.getElementById('erase');
   const gsizeMinInput = document.getElementById('gsizeMin');
   const gsizeMaxInput = document.getElementById('gsizeMax');
+  const countdownEl = document.getElementById('countdown');
 
   const translations = {
     en: {
@@ -318,6 +319,27 @@
     generateBtn.disabled = true;
   }
 
+  function runCountdown(callback) {
+    let num = 5;
+    const tick = () => {
+      countdownEl.textContent = num;
+      countdownEl.classList.add('show');
+      setTimeout(() => {
+        countdownEl.classList.remove('show');
+        setTimeout(() => {
+          num--;
+          if (num > 0) {
+            tick();
+          } else {
+            countdownEl.textContent = '';
+            if (callback) callback();
+          }
+        }, 500);
+      }, 500);
+    };
+    tick();
+  }
+
   generateBtn.addEventListener('click', (e) => {
     e.preventDefault();
     generateNumber();
@@ -325,7 +347,11 @@
 
   generateAllBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    generateAllNumbers();
+    generateAllBtn.disabled = true;
+    runCountdown(() => {
+      generateAllNumbers();
+      generateAllBtn.disabled = false;
+    });
   });
 
   resetBtn.addEventListener('click', (e) => {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
       <div class="groups-header">
         <h2 id="groupsHeading">그룹 내 인원</h2>
         <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
+        <span class="gsize-sep" aria-hidden="true">~</span>
         <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
         <button id="generateAll" type="button">모두 생성</button>
       </div>
@@ -67,5 +68,6 @@
       <button id="lang-en" type="button">English</button>
     </div>
   </main>
+  <div id="countdown" class="countdown" aria-hidden="true"></div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -215,6 +215,10 @@ button:focus, input:focus {
   border-radius: 4px;
 }
 
+.groups-header .gsize-sep {
+  font-weight: bold;
+}
+
 .groups-container {
   display: flex;
   flex-wrap: wrap;
@@ -313,5 +317,27 @@ button:focus, input:focus {
 }
 
 .home-button:hover {
+  opacity: 1;
+}
+
+.countdown {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 6rem;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.5s;
+  pointer-events: none;
+  z-index: 2000;
+}
+
+.countdown.show {
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add tilde separator between group size inputs
- show 5–1 fade countdown before generating all numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bbbeabcde8832aa6ce4cb736abd6a7