### PR TITLE
Adjust button layout for clarity

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@
       copied: '클립보드에 복사완료',
       enterRange: '최소와 최대 값을 입력하세요.',
       allGenerated: '범위의 모든 숫자를 생성했습니다.',
-      groups: '그룹 내 인원',
+      groups: '그룹 내\n인원',
       group: '그룹',
       generateAll: '모두 생성'
     }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,8 @@
     </section>
     <section id="groupsSection" class="groups">
       <div class="groups-header">
-        <h2 id="groupsHeading">그룹 내 인원</h2>
+        <h2 id="groupsHeading">그룹 내
+        인원</h2>
         <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
         <span class="gsize-sep" aria-hidden="true">~</span>
         <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,7 @@ button {
   font-size: 1.2rem;
   cursor: pointer;
   transition: background 0.2s, box-shadow 0.2s;
+  white-space: nowrap;
 }
 
 button:hover {
@@ -201,6 +202,10 @@ button:focus, input:focus {
 
 .groups h2 {
   font-size: 1.2rem;
+}
+
+#groupsHeading {
+  white-space: pre-line;
 }
 
 .groups-header {
@@ -302,6 +307,8 @@ button:focus, input:focus {
 
 .lang-buttons button {
   margin: 0 0.5rem;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
 }
 
 .lang-sep {


### PR DESCRIPTION
## Summary
- Reduce Korean/English toggle button size to 0.8rem with tighter padding
- Keep button labels on a single line and split the group heading into two lines

## Testing
- `npm test`
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bd5f504fb8832aafd6908c897acfc3