### PR TITLE
Center layout and streamline controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@
       copied: '클립보드에 복사완료',
       enterRange: '최소와 최대 값을 입력하세요.',
       allGenerated: '범위의 모든 숫자를 생성했습니다.',
-      groups: '그룹 내\n인원',
+      groups: '그룹 내 인원',
       group: '그룹',
       generateAll: '모두 생성'
     }
@@ -429,8 +429,14 @@
     renderGroups();
   }
 
-  langKoBtn.addEventListener('click', () => switchLanguage('ko'));
-  langEnBtn.addEventListener('click', () => switchLanguage('en'));
+  langKoBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    switchLanguage('ko');
+  });
+  langEnBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    switchLanguage('en');
+  });
 
   gsizeMinInput.value = 4;
   gsizeMaxInput.value = 5;

--- a/index.html
+++ b/index.html
@@ -54,8 +54,7 @@
     </section>
     <section id="groupsSection" class="groups">
       <div class="groups-header">
-        <h2 id="groupsHeading">그룹 내
-        인원</h2>
+        <h2 id="groupsHeading">그룹 내 인원</h2>
         <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
         <span class="gsize-sep" aria-hidden="true">~</span>
         <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
@@ -64,9 +63,9 @@
       <div id="groupsContainer" class="groups-container"></div>
     </section>
     <div class="lang-buttons">
-      <button id="lang-ko" type="button">한국어</button>
+      <a href="#" id="lang-ko">한국어</a>
       <span class="lang-sep" aria-hidden="true">|</span>
-      <button id="lang-en" type="button">English</button>
+      <a href="#" id="lang-en">English</a>
     </div>
   </main>
   <div id="countdown" class="countdown" aria-hidden="true"></div>

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ body {
   background: #f0f0f0;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   min-height: 100vh;
 }
 
@@ -102,6 +102,12 @@ h1 {
   display: flex;
   gap: 1rem;
   flex: 1 1 100%;
+}
+
+.buttons button,
+#generateAll {
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
 }
 
 button {
@@ -204,14 +210,15 @@ button:focus, input:focus {
   font-size: 1.2rem;
 }
 
-#groupsHeading {
-  white-space: pre-line;
-}
-
 .groups-header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.groups-header h2 {
+  flex: 1;
+  margin: 0;
 }
 
 .groups-header .gsize-input {
@@ -305,10 +312,11 @@ button:focus, input:focus {
   text-align: center;
 }
 
-.lang-buttons button {
+.lang-buttons a {
   margin: 0 0.5rem;
   font-size: 0.8rem;
-  padding: 0.3rem 0.6rem;
+  color: #1e293b;
+  text-decoration: underline;
 }
 
 .lang-sep {


### PR DESCRIPTION
## Summary
- Vertically center main container and resize action buttons for a cleaner layout
- Keep group heading on a single line and present language switches as simple text links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bd6440ef24832aa93307d32f417474