### PR TITLE
Add labels and enlarge group size inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,15 @@
     <section id="groupsSection" class="groups">
       <div class="groups-header">
         <h2 id="groupsHeading">그룹 내 인원</h2>
-        <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
+        <div class="gsize-field">
+          <label for="gsizeMin">Min(최소)</label>
+          <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
+        </div>
         <span class="gsize-sep" aria-hidden="true">~</span>
-        <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
+        <div class="gsize-field">
+          <label for="gsizeMax">Max(최대)</label>
+          <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
+        </div>
         <button id="generateAll" type="button">모두 생성</button>
       </div>
       <div id="groupsContainer" class="groups-container"></div>

--- a/styles.css
+++ b/styles.css
@@ -212,7 +212,7 @@ button:focus, input:focus {
 
 .groups-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 0.5rem;
 }
 
@@ -221,9 +221,21 @@ button:focus, input:focus {
   margin: 0;
 }
 
+.groups-header .gsize-field {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.groups-header .gsize-field label {
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
+}
+
 .groups-header .gsize-input {
-  width: 3rem;
-  padding: 0.2rem 0.4rem;
+  width: 4rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
   border: 1px solid #e2e8f0;
   border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- Add Min(최소) and Max(최대) labels above group size inputs and align them with the button
- Increase group size input dimensions to match the Generate All button

## Testing
- `npm test`
- `python3 -m http.server 8000 & sleep 1; curl -I http://localhost:8000/index.html; kill $SERVER_PID`

------
https://chatgpt.com/codex/tasks/task_b_68bd665ec868832a9d138c7e2e94d04e