### PR TITLE
Center group controls and localize size labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@
   const eraseBtn = document.getElementById('erase');
   const gsizeMinInput = document.getElementById('gsizeMin');
   const gsizeMaxInput = document.getElementById('gsizeMax');
+  const gsizeMinLabel = document.getElementById('gsizeMinLabel');
+  const gsizeMaxLabel = document.getElementById('gsizeMaxLabel');
   const countdownEl = document.getElementById('countdown');
 
   const translations = {
@@ -44,7 +46,9 @@
       allGenerated: 'All numbers in the range have been generated.',
       groups: 'Minimum group members',
       group: 'Group',
-      generateAll: 'Generate All'
+      generateAll: 'Generate All',
+      gsizeMin: 'Min',
+      gsizeMax: 'Max'
     },
     ko: {
       title: '신가성의 숫자들',
@@ -63,7 +67,9 @@
       allGenerated: '범위의 모든 숫자를 생성했습니다.',
       groups: '그룹 내 인원',
       group: '그룹',
-      generateAll: '모두 생성'
+      generateAll: '모두 생성',
+      gsizeMin: '최소',
+      gsizeMax: '최대'
     }
   };
 
@@ -413,6 +419,8 @@
     eraseBtn.textContent = t.erase;
     historyHeading.textContent = t.history;
     groupsHeading.textContent = t.groups;
+    gsizeMinLabel.textContent = t.gsizeMin;
+    gsizeMaxLabel.textContent = t.gsizeMax;
     generateAllBtn.textContent = t.generateAll;
     copyBtn.setAttribute('aria-label', t.copy);
     if (copyTooltip.textContent) copyTooltip.textContent = t.copied;

--- a/index.html
+++ b/index.html
@@ -56,12 +56,12 @@
       <div class="groups-header">
         <h2 id="groupsHeading">그룹 내 인원</h2>
         <div class="gsize-field">
-          <label for="gsizeMin">Min(최소)</label>
+          <label for="gsizeMin" id="gsizeMinLabel">최소</label>
           <input type="number" id="gsizeMin" class="gsize-input" min="1" value="4">
         </div>
         <span class="gsize-sep" aria-hidden="true">~</span>
         <div class="gsize-field">
-          <label for="gsizeMax">Max(최대)</label>
+          <label for="gsizeMax" id="gsizeMaxLabel">최대</label>
           <input type="number" id="gsizeMax" class="gsize-input" min="1" value="5">
         </div>
         <button id="generateAll" type="button">모두 생성</button>

--- a/styles.css
+++ b/styles.css
@@ -212,12 +212,13 @@ button:focus, input:focus {
 
 .groups-header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: center;
   gap: 0.5rem;
+  padding: 0.5rem 0;
 }
 
 .groups-header h2 {
-  flex: 1;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- Align group size controls and generate-all button in one centered row
- Translate group size labels to Min/Max or 최소/최대 based on selected language

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bd68ed78c4832aa1952e9440f7bb70