### PR TITLE
Ensure favicon links use src assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>신가성의 숫자들</title>
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" sizes="any" href="src/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
-  <link rel="shortcut icon" href="src/favicon.ico">
   <link rel="manifest" href="src/site.webmanifest">
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
## Summary
- point the page favicon link to the ico asset in src while keeping existing png options

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69251bf40024832a92ba1b34140a6907)